### PR TITLE
Add Flyway dependencies to runtime classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ src/main/java/point/ttodoApi/
 
 ```bash
 ./gradlew bootRun        # 애플리케이션 실행
+./gradlew compileJava   # 컴파일 테스트
 ./gradlew test           # 테스트 실행
 ./gradlew build          # 빌드
 ./gradlew clean build    # 클린 빌드

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-database-postgresql'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
## Summary
- add Flyway core and PostgreSQL database support dependencies to the Gradle build so migrations can run
- document the compileJava task in the README so contributors can run the requested compile check

## Testing
- ./gradlew compileJava --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68e53d765534832d806a3932bddadf4e